### PR TITLE
Restrict IAM Policy for Route53 Record Changes to Specific Hosted Zone

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "route53_access" {
     actions = [
       "route53:ChangeResourceRecordSets"
     ]
-    resources = ["*"]
+    resources = ["arn:aws:route53:::hostedzone/${var.hosted_zone_id}"]
   }
 
   statement {


### PR DESCRIPTION
## Summary
This pull request enhances security by updating the IAM policy to follow the principle of least privilege. Previously, the `route53:ChangeResourceRecordSets` permission was granted on all resources (*), which posed a potential security risk. This update restricts the permission to a specific hosted zone.

## Changes Made
- Updated the IAM policy to specify the Hosted Zone ARN instead of using a wildcard (*).
- This ensures that only DNS records within the designated hosted zone can be modified.

## Code Changes
### Original Code (Overly Permissive Policy)
```hcl
data "aws_iam_policy_document" "route53_access" {
  statement {
    actions = [
      "route53:ChangeResourceRecordSets"
    ]
    resources = ["*"]
  }
```

### Updated Code (Least Privilege Applied)
```hcl
data "aws_iam_policy_document" "route53_access" {
  statement {
    actions = [
      "route53:ChangeResourceRecordSets"
    ]
    resources = ["arn:aws:route53:::hostedzone/${var.hosted_zone_id}"]
  }
```

## Why This Change is Needed
- The existing policy allows modifying records in any hosted zone within the AWS account, which increases security risks.
- Restricting permissions to only the necessary hosted zone improves security and follows AWS least privilege best practices.
- Prevents accidental or unauthorized DNS record modifications in other hosted zones.

## Potential Impact
- Workloads using this IAM policy should verify they only need access to the specified hosted zone.
- If access to multiple hosted zones is needed, additional ARNs can be added to the resources list.

## Testing and Validation
- Verified that record modifications within the specified hosted zone succeed.
- Confirmed that attempting to modify records outside the designated hosted zone fails as expected.